### PR TITLE
Implement sending email greetings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,14 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- Mail -->
+        <dependency>
+            <groupId>javax.mail</groupId>
+            <artifactId>mail</artifactId>
+            <version>1.5.0-b01</version>
+            <type>jar</type>
+        </dependency>
+
         <!-- Swagger -->
         <dependency>
             <groupId>io.springfox</groupId>

--- a/src/main/java/org/wyona/webapp/Server.java
+++ b/src/main/java/org/wyona/webapp/Server.java
@@ -12,9 +12,7 @@ import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
 @EnableSwagger2
 @SpringBootApplication
-@ComponentScan(basePackageClasses = {
-    HelloWorldController.class
-})
+@ComponentScan
 
 /**
  *

--- a/src/main/java/org/wyona/webapp/controllers/HelloWorldController.java
+++ b/src/main/java/org/wyona/webapp/controllers/HelloWorldController.java
@@ -1,8 +1,11 @@
 package org.wyona.webapp.controllers;
 
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
@@ -14,6 +17,9 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 
 import org.wyona.webapp.models.Greeting;
+import org.wyona.webapp.services.MailerService;
+
+import javax.mail.MessagingException;
 
 /**
  * 'Hello World' Controller 
@@ -24,16 +30,30 @@ public class HelloWorldController {
 
     private static final Logger logger = LogManager.getLogger("HelloWorldController");
 
+    private MailerService mailerService;
+
+    @Autowired
+    public HelloWorldController(MailerService mailerService){
+        this.mailerService = mailerService;
+    }
+
     /**
      * Send greetings by email
      */
     @RequestMapping(method = RequestMethod.GET, produces = "application/json")
-    @ApiOperation(value="Generate greeting and send greeting as email when address specified") 
+    @ApiOperation(value="Generate greeting and send greeting as email when address specified")
+    @ApiResponses(value = {
+            @ApiResponse(code = 400, message = "Bad Request, e.g. provided email parameter is not valid email address")
+    })
     public ResponseEntity<Greeting> getGreeting(
         @ApiParam(name = "email", value = "email address greeting will be sent to, e.g. 'michael.wechner@wyona.com'", required = false) @RequestParam(name = "email", required = false) String email
-        ) {
+        ) throws MessagingException {
         logger.info(new Greeting().getGreeting());
-        // TODO: Send email
+
+        if(email != null && !email.isEmpty()) {
+            mailerService.sendEmailGreeting(email, "Hello World!", "Hello World!");
+        }
+
         return new ResponseEntity<>(new Greeting(), HttpStatus.OK);
     }
 }

--- a/src/main/java/org/wyona/webapp/controllers/HelloWorldController.java
+++ b/src/main/java/org/wyona/webapp/controllers/HelloWorldController.java
@@ -48,12 +48,14 @@ public class HelloWorldController {
     public ResponseEntity<Greeting> getGreeting(
         @ApiParam(name = "email", value = "email address greeting will be sent to, e.g. 'michael.wechner@wyona.com'", required = false) @RequestParam(name = "email", required = false) String email
         ) throws MessagingException {
-        logger.info(new Greeting().getGreeting());
+
+        Greeting greeting = new Greeting("World");
+        logger.info(greeting.getGreeting());
 
         if(email != null && !email.isEmpty()) {
-            mailerService.sendEmailGreeting(email, "Hello World!", "Hello World!");
+            mailerService.sendEmailGreeting(email, greeting.getGreeting(), greeting.getGreeting());
         }
 
-        return new ResponseEntity<>(new Greeting(), HttpStatus.OK);
+        return new ResponseEntity<>(greeting, HttpStatus.OK);
     }
 }

--- a/src/main/java/org/wyona/webapp/exceptions/RestExceptionHandler.java
+++ b/src/main/java/org/wyona/webapp/exceptions/RestExceptionHandler.java
@@ -1,0 +1,22 @@
+package org.wyona.webapp.exceptions;
+
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+import org.wyona.webapp.models.ErrorResponse;
+
+import javax.mail.SendFailedException;
+
+@Order(Ordered.HIGHEST_PRECEDENCE)
+@ControllerAdvice
+public class RestExceptionHandler extends ResponseEntityExceptionHandler {
+
+    @ExceptionHandler(SendFailedException.class)
+    protected ResponseEntity<Object> handleSendFailedException(SendFailedException ex) {
+        return new ResponseEntity<>(new ErrorResponse(ex.getMessage()), HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/org/wyona/webapp/mail/EmailSender.java
+++ b/src/main/java/org/wyona/webapp/mail/EmailSender.java
@@ -20,10 +20,14 @@ public class EmailSender {
         Properties props = new Properties();
         props.put("mail.transport.protocol", "smtp");
         props.put("mail.smtp.auth", true);
-        props.put("mail.smtp.starttls.enable", true);
+
+        // TODO: Seems to cause trouble, when the mail server uses a self-signed certificate
+        //props.put("mail.smtp.starttls.enable", true);
+
         props.put("mail.smtp.host", config.getHost());
         props.put("mail.smtp.port", config.getPort());
 
+        // TODO: Make from address configurable
         fromEmail = "greetings@" + config.getHost();
 
         session = Session.getInstance(
@@ -36,6 +40,9 @@ public class EmailSender {
         );
     }
 
+    /**
+     * Send greetings by email
+     */
     public void sendEmailGreeting(String email, String subject, String text) throws MessagingException {
         Message message = new SMTPMessage(session);
         message.setFrom(new InternetAddress(fromEmail));

--- a/src/main/java/org/wyona/webapp/mail/EmailSender.java
+++ b/src/main/java/org/wyona/webapp/mail/EmailSender.java
@@ -1,0 +1,47 @@
+package org.wyona.webapp.mail;
+
+import com.sun.mail.smtp.SMTPMessage;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import javax.mail.*;
+import javax.mail.internet.InternetAddress;
+import java.util.Properties;
+
+@Component
+public class EmailSender {
+
+    private final Session session;
+    private final String fromEmail;
+
+    @Autowired
+    public EmailSender(EmailSenderCofig config){
+
+        Properties props = new Properties();
+        props.put("mail.transport.protocol", "smtp");
+        props.put("mail.smtp.auth", true);
+        props.put("mail.smtp.starttls.enable", true);
+        props.put("mail.smtp.host", config.getHost());
+        props.put("mail.smtp.port", config.getPort());
+
+        fromEmail = "greetings@" + config.getHost();
+
+        session = Session.getInstance(
+                props,
+                new Authenticator() {
+                    protected PasswordAuthentication getPasswordAuthentication() {
+                        return new PasswordAuthentication(config.getUsername(), config.getPassword());
+                    }
+                }
+        );
+    }
+
+    public void sendEmailGreeting(String email, String subject, String text) throws MessagingException {
+        Message message = new SMTPMessage(session);
+        message.setFrom(new InternetAddress(fromEmail));
+        message.setRecipients(Message.RecipientType.TO, InternetAddress.parse(email));
+        message.setSubject(subject);
+        message.setText(text);
+        Transport.send(message);
+    }
+}

--- a/src/main/java/org/wyona/webapp/mail/EmailSenderCofig.java
+++ b/src/main/java/org/wyona/webapp/mail/EmailSenderCofig.java
@@ -1,0 +1,36 @@
+package org.wyona.webapp.mail;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+class EmailSenderCofig {
+
+    @Value("${app.mail.host}")
+    private String host;
+
+    @Value("${app.mail.port}")
+    private int port;
+
+    @Value("${app.mail.username}")
+    private String username;
+
+    @Value("${app.mail.password}")
+    private String password;
+
+    String getHost() {
+        return host;
+    }
+
+    int getPort() {
+        return port;
+    }
+
+    String getUsername() {
+        return username;
+    }
+
+    String getPassword() {
+        return password;
+    }
+}

--- a/src/main/java/org/wyona/webapp/models/ErrorResponse.java
+++ b/src/main/java/org/wyona/webapp/models/ErrorResponse.java
@@ -1,0 +1,17 @@
+package org.wyona.webapp.models;
+
+/**
+ * Helper class that holds response message in case when an error occurs, e.g.
+ * when sending greeting emails fails due to bad destination address
+ */
+public class ErrorResponse {
+    private String message;
+
+    public ErrorResponse(String message) {
+        this.message = message;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/org/wyona/webapp/models/Greeting.java
+++ b/src/main/java/org/wyona/webapp/models/Greeting.java
@@ -5,10 +5,19 @@ package org.wyona.webapp.models;
  */
 public class Greeting {
 
+    private String name;
+
+    /**
+     *
+     */
+    public Greeting(String name) {
+        this.name  = name;
+    }
+
     /**
      *
      */
     public String getGreeting() {
-        return "Hello World";
+        return "Hello " + name;
     }
 }

--- a/src/main/java/org/wyona/webapp/services/MailerService.java
+++ b/src/main/java/org/wyona/webapp/services/MailerService.java
@@ -1,0 +1,26 @@
+package org.wyona.webapp.services;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.wyona.webapp.mail.EmailSender;
+
+import javax.mail.MessagingException;
+
+@Component
+public class MailerService {
+    private static final Logger logger = LogManager.getLogger("MailerService");
+
+    private final EmailSender emailSender;
+
+    @Autowired
+    public MailerService(EmailSender emailSender) {
+        this.emailSender = emailSender;
+    }
+
+    public void sendEmailGreeting(String email, String subject, String text) throws MessagingException {
+        emailSender.sendEmailGreeting(email, subject, text);
+        logger.info("Email greeting sent to {}", email);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,5 @@
 #logging.level.org.springframework.web=DEBUG
+app.mail.host=mail.wyona.com
+app.mail.port=587
+app.mail.username=USERNAME
+app.mail.password=PASSWORD

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,14 @@
 #logging.level.org.springframework.web=DEBUG
-app.mail.host=mail.wyona.com
+
+# Mail server (outgoing) configuration
+
+# INFO: When using gmail, then you probably have to "allow less secure apps" for your gmail account: https://myaccount.google.com/lesssecureapps
+app.mail.host=smtp.gmail.com
 app.mail.port=587
 app.mail.username=USERNAME
 app.mail.password=PASSWORD
+
+#app.mail.host=mail.wyona.com
+#app.mail.port=587
+#app.mail.username=USERNAME
+#app.mail.password=PASSWORD


### PR DESCRIPTION
When `email` parameter is provided in the request, greeting email will be sent to provided address. Note that proper email provider params need to be set up in `application.properties`. Implementation is tested with Gmail's SMTP server.